### PR TITLE
Add support for custom user data for worker nodes.

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -58,7 +58,8 @@ export interface ClusterOptions {
 
     /**
      * Extra code to run on node startup. This code will run after the AWS EKS bootstrapping code and before the node
-     * signals its readiness to the managing CloudFormation stack.
+     * signals its readiness to the managing CloudFormation stack. This code must be a typical user data script:
+     * critically it must begin with an interpreter directive (i.e. a `#!`).
      */
     nodeUserData?: pulumi.Input<string>;
 


### PR DESCRIPTION
These changes add a new argument, `nodeUserData`, that specifies
additional user code to run upon node startup. This code must be
formatted like other user data--e.g. it must start with an interpreter
line (`#!`)--and will be run after EKS bootrstrapping but before the
node signals readiness to CF.