### PR TITLE
`aws-iam-authenticator` improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ or `yarn`:
 
     $ yarn add @pulumi/eks
 
+
+This package requires `aws-iam-authenticator` for Amazon EKS in order to deploy resources to EKS clusters. Install this
+tool using the [official instructions](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-prereqs)
+under "To install aws-iam-authenticator for Amazon EKS".
+
 ## Concepts
 
 This package provides a Pulumi component that creates and manages the resource necessary to run an EKS Kubernetes

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -18,6 +18,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
+import which = require("which");
 
 import { ServiceRole } from "./servicerole";
 import { createStorageClass, EBSVolumeType, StorageClass } from "./storageclass";
@@ -156,6 +157,14 @@ export class Cluster extends pulumi.ComponentResource {
         super("eks:index:Cluster", name, args, opts);
 
         args = args || {};
+
+        // Check to ensure that aws-iam-authenticator is installed, as we'll need it in order to deploy k8s resources
+        // to the EKS cluster.
+        try {
+            which.sync("aws-iam-authenticator");
+        } catch (err) {
+            throw new pulumi.RunError("Could not find aws-iam-authenticator for EKS. See https://github.com/pulumi/eks#installing for installation instructions.");
+        }
 
         // If no VPC was specified, use the default VPC.
         let vpcId: pulumi.Input<string> = args.vpcId!;

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -13,10 +13,12 @@
     "dependencies": {
         "@pulumi/aws": "dev",
         "@pulumi/kubernetes": "^v0.17.0",
-        "@pulumi/pulumi": "dev"
+        "@pulumi/pulumi": "dev",
+        "which": "^1.3.1"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",
+        "@types/which": "^1.3.1",
         "tslint": "^5.7.0",
         "typescript": "^2.6.2"
     }

--- a/nodejs/eks/yarn.lock
+++ b/nodejs/eks/yarn.lock
@@ -139,6 +139,10 @@
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
 
+"@types/which@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.1.tgz#7802c380887986ca909008afea4e08025b130f8d"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -500,6 +504,10 @@ is-fullwidth-code-point@^2.0.0:
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -1010,6 +1018,12 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+which@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  dependencies:
+    isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
1. Provide a friendlier error message if `aws-iam-authenticator` is not
   installed
2. Add installation instruactions for the same to the README

Fixes #2
Fixes #13