### PR TITLE
Add support for setting CNI options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ install:
     # Install Pulumi
     - curl -L https://get.pulumi.com/ | bash -s -- --version 0.15.0
     - export PATH=$HOME/.pulumi/bin:$PATH
+    # Install kubectl
+    - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    - chmod +x ./kubectl
+    - sudo mv kubectl /usr/local/bin
 before_script:
     - ${PULUMI_SCRIPTS}/ci/ensure-dependencies
 script:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This package requires `aws-iam-authenticator` for Amazon EKS in order to deploy 
 tool using the [official instructions](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-prereqs)
 under "To install aws-iam-authenticator for Amazon EKS".
 
+`kubectl` is also required if any VPC CNI options are configured; installation instructions are [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
+
 ## Concepts
 
 This package provides a Pulumi component that creates and manages the resource necessary to run an EKS Kubernetes

--- a/nodejs/eks/Makefile
+++ b/nodejs/eks/Makefile
@@ -14,6 +14,7 @@ build::
 	sed -e 's/\$${VERSION}/$(VERSION)/g' < package.json > bin/package.json
 	cp ../../README.md ../../LICENSE bin/
 	cp -R dashboard bin/
+	cp -R cni bin/
 
 lint::
 	tslint -c ../tslint.json -p tsconfig.json

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -21,6 +21,7 @@ import * as jsyaml from "js-yaml";
 import * as path from "path";
 import which = require("which");
 
+import { Cni, CniOptions } from "./cni";
 import { ServiceRole } from "./servicerole";
 import { createStorageClass, EBSVolumeType, StorageClass } from "./storageclass";
 import transform from "./transform";
@@ -92,6 +93,12 @@ export interface ClusterOptions {
      * Optional mappings from AWS IAM users to Kubernetes users and groups.
      */
     userMappings?: pulumi.Input<pulumi.Input<UserMapping>[]>;
+
+    /**
+     * The configiuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation
+     * for the CniOptions type.
+     */
+    cniOptions?: CniOptions;
 
     /**
      * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
@@ -312,6 +319,9 @@ export class Cluster extends pulumi.ComponentResource {
             kubeconfig: myKubeconfig.apply(JSON.stringify),
         }, { parent: this });
 
+        // Create the CNI management resource.
+        const cni = new Cni(`${name}-cni`, myKubeconfig, args.cniOptions, { parent: this });
+
         // Enable access to the EKS cluster for worker nodes.
         const instanceRoleMapping: RoleMapping = {
             roleArn: instanceRoleARN,
@@ -494,7 +504,7 @@ ${customUserData}
         const cfnStack = new aws.cloudformation.Stack(`${name}-nodes`, {
             name: cfnStackName,
             templateBody: cfnTemplateBody,
-        }, { parent: this, dependsOn: eksNodeAccess });
+        }, { parent: this, dependsOn: [eksNodeAccess, cni] });
 
         // Export the cluster's kubeconfig with a dependency upon the cluster's autoscaling group. This will help
         // ensure that the cluster's consumers do not attempt to use the cluster until its workers are attached.

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -1,0 +1,152 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as childProcess from "child_process";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as jsyaml from "js-yaml";
+import * as path from "path";
+import * as process from "process";
+import * as tmp from "tmp";
+
+/**
+ * CniOptions describes the configuration options available for the Amazon VPC CNI plugin for Kubernetes.
+ */
+export interface CniOptions {
+    /**
+     * Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires
+     * additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
+     *
+     * Defaults to true.
+     */
+    nodePortSupport?: pulumi.Input<boolean>;
+
+    /**
+     * Specifies that your pods may use subnets and security groups (within the same VPC as your control plane
+     * resources) that are independent of your cluster's `resourcesVpcConfig`.
+     *
+     * Defaults to false.
+     */
+    customNetworkConfig?: pulumi.Input<boolean>;
+
+    /**
+     * Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set
+     * to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have
+     * already been applied.
+     *
+     * Defaults to false.
+     */
+    externalSnat?: pulumi.Input<boolean>;
+
+    /**
+     * Specifies the number of free elastic network interfaces (and all of their available IP addresses) that the ipamD
+     * daemon should attempt to keep available for pod assignment on the node.
+     *
+     * Defaults to 1.
+     */
+    warmEniTarget?: pulumi.Input<number>;
+
+    /**
+     * Specifies the number of free IP addresses that the ipamD daemon should attempt to keep available for pod
+     * assignment on the node.
+     */
+    warmIpTarget?: pulumi.Input<number>;
+}
+
+interface CniInputs {
+    kubeconfig: string;
+    nodePortSupport?: boolean;
+    customNetworkConfig?: boolean;
+    externalSnat?: boolean;
+    warmEniTarget?: number;
+    warmIpTarget?: number;
+}
+
+function computeCniYaml(yamlPath: string, args: CniInputs): string {
+    // Read the CNI YAML
+    const cniYamlText = fs.readFileSync(yamlPath).toString();
+    const cniYaml = jsyaml.safeLoadAll(cniYamlText);
+
+    // Rewrite the envvars for the CNI daemon set as per the inputs.
+    const daemonSet = cniYaml.filter(o => o.kind === "DaemonSet")[0];
+    const env = daemonSet.spec.template.spec.containers[0].env;
+    if (args.nodePortSupport !== undefined) {
+        env.push({name: "AWS_VPC_CNI_NODE_PORT_SUPPORT", value: args.nodePortSupport ? "true" : "false"});
+    }
+    if (args.customNetworkConfig !== undefined) {
+        env.push({name: "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG", value: args.customNetworkConfig ? "true" : "false"});
+    }
+    if (args.externalSnat !== undefined) {
+        env.push({name: "AWS_VPC_K8S_CNI_EXTERNALSNAT", value: args.externalSnat ? "true" : "false"});
+    }
+    if (args.warmEniTarget !== undefined) {
+        env.push({name: "WARM_ENI_TARGET", value: args.warmEniTarget.toString()});
+    }
+    if (args.warmIpTarget !== undefined) {
+        env.push({name: "WARM_IP_TARGET", value: args.warmIpTarget.toString()});
+    }
+    // Return the computed YAML.
+    return cniYaml.map(o => `---\n${jsyaml.safeDump(o)}`).join("");
+}
+
+function applyCniYaml(yamlPath: string, args: CniInputs) {
+    // Dump the kubeconfig to a file.
+    const tmpKubeconfig = tmp.fileSync();
+    fs.writeFileSync(tmpKubeconfig.fd, args.kubeconfig);
+
+    // Compute the required CNI YAML and dump it to a file.
+    const tmpYaml = tmp.fileSync();
+    fs.writeFileSync(tmpYaml.fd, computeCniYaml(yamlPath, args));
+
+    // Call kubectl to apply the YAML.
+    childProcess.execSync(`kubectl apply -f ${tmpYaml.name}`, {
+        env: { ...process.env, "KUBECONFIG": tmpKubeconfig.name },
+    });
+}
+
+/**
+ * Cni manages the configuration of the Amazon VPC CNI plugin for Kubernetes by applying its YAML chart. Once Pulumi is
+ * able to programatically manage existing infrastructure, we can replace this with a real k8s resource.
+ */
+export class Cni extends pulumi.dynamic.Resource {
+    constructor(name: string, kubeconfig: pulumi.Input<any>, args?: CniOptions, opts?: pulumi.CustomResourceOptions) {
+        const yamlPath = path.join(__dirname, "cni", "aws-k8s-cni.yaml");
+
+        const provider = {
+            check: (state: any, inputs: any) => Promise.resolve({inputs: inputs, failedChecks: []}),
+            diff: (id: pulumi.ID, state: any, inputs: any) => Promise.resolve({}),
+            create: (inputs: any) => {
+                applyCniYaml(yamlPath, <CniInputs>inputs);
+                return Promise.resolve({id: crypto.randomBytes(8).toString("hex"), outs: {}});
+            },
+            update: (id: pulumi.ID, state: any, inputs: any) => {
+                applyCniYaml(yamlPath, <CniInputs>inputs);
+                return Promise.resolve({outs: {}});
+            },
+            read: (id: pulumi.ID, state: any) => Promise.resolve({id: id, props: state}),
+            delete: (id: pulumi.ID, state: any) => Promise.resolve(),
+        };
+
+        args = args || {};
+        super(provider, name, {
+            kubeconfig: pulumi.output(kubeconfig).apply(JSON.stringify),
+            nodePortSupport: args.nodePortSupport,
+            customNetworkConfig: args.customNetworkConfig,
+            externalSnat: args.externalSnat,
+            warmEniTarget: args.warmEniTarget,
+            warmIpTarget: args.warmIpTarget,
+        }, opts);
+    }
+}

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -20,6 +20,7 @@ import * as jsyaml from "js-yaml";
 import * as path from "path";
 import * as process from "process";
 import * as tmp from "tmp";
+import which = require("which");
 
 /**
  * CniOptions describes the configuration options available for the Amazon VPC CNI plugin for Kubernetes.
@@ -122,6 +123,13 @@ function applyCniYaml(yamlPath: string, args: CniInputs) {
  */
 export class Cni extends pulumi.dynamic.Resource {
     constructor(name: string, kubeconfig: pulumi.Input<any>, args?: CniOptions, opts?: pulumi.CustomResourceOptions) {
+        // Check to ensure that kubectl is installed, as we'll need it in order to deploy k8s resources below.
+        try {
+            which.sync("kubectl");
+        } catch (err) {
+            throw new pulumi.RunError("Could not find kubectl. See https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl for installation instructions.");
+        }
+
         const yamlPath = path.join(__dirname, "cni", "aws-k8s-cni.yaml");
 
         const provider = {

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -127,4 +127,3 @@ spec:
     singular: eniconfig
     kind: ENIConfig
 
-

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: aws-node
+rules:
+- apiGroups:
+  - crd.k8s.amazonaws.com
+  resources:
+  - "*"
+  - namespaces
+  verbs:
+  - "*"
+- apiGroups: [""]
+  resources:
+  - pods
+  - nodes
+  - namespaces
+  verbs: ["list", "watch", "get"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    k8s-app: aws-node
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        k8s-app: aws-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: aws-node
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      containers:
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.2.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 60000
+          name: metrics
+        name: aws-node
+        env:
+          - name: AWS_VPC_K8S_CNI_LOGLEVEL
+            value: DEBUG
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+        - mountPath: /host/var/log
+          name: log-dir
+        - mountPath: /var/run/docker.sock
+          name: dockersock
+      volumes:
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: log-dir
+        hostPath:
+          path: /var/log
+      - name: dockersock
+        hostPath:
+          path: /var/run/docker.sock
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  version: v1alpha1
+  names:
+    scope: Cluster
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig
+
+

--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 export * from "./cluster";
+export { CniOptions } from "./cni";
 export * from "./storageclass";

--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -13,5 +13,5 @@
 // limitations under the License.
 
 export * from "./cluster";
-export { CniOptions } from "./cni";
+export { VpcCniOptions } from "./cni";
 export * from "./storageclass";

--- a/nodejs/eks/tsconfig.json
+++ b/nodejs/eks/tsconfig.json
@@ -16,6 +16,7 @@
     },
     "files": [
         "cluster.ts",
+        "cni.ts",
         "index.ts",
         "servicerole.ts",
         "storageclass.ts"


### PR DESCRIPTION
Add a new field to the cluster config, `CniOptions`, that allows the
user to configure options for the Amazon VPC CNI plugin for Kubernetes.

This is currently implemented by shelling out to kubectl from a dynamic
resource. Once we are able to programatically take ownership of existing
resources, we should use proper k8s resources instead.