### PR TITLE
Filter public subnets as necessary

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -36,7 +36,9 @@ export interface ClusterOptions {
 
     /**
      * The subnets to attach to the EKS cluster. If either vpcId or subnetIds is unset, the cluster will use the
-     * default VPC's subnets.
+     * default VPC's subnets. If the list of subnets includes both public and private subnets, the Kubernetes API
+     * server and the worker nodes will only be attached to the private subnets. See
+     * https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html for more details.
      */
     subnetIds?: pulumi.Input<pulumi.Input<string>[]>;
 
@@ -383,14 +385,14 @@ ${customUserData}
             userData: userdata,
         }, { parent: this });
 
-        const cfnSubnetIds = pulumi.output(subnetIds).apply(ids => pulumi.all(ids.map(pulumi.output))).apply(ids => JSON.stringify(ids));
+        const workerSubnetIds = pulumi.output(subnetIds).apply(ids => computeWorkerSubnets(this, ids));
         const cfnTemplateBody = pulumi.all([
             nodeLaunchConfiguration.id,
             args.desiredCapacity || 2,
             args.minSize || 1,
             args.maxSize || 2,
             eksCluster.name,
-            cfnSubnetIds,
+            workerSubnetIds.apply(JSON.stringify),
         ]).apply(([launchConfig, desiredCapacity, minSize, maxSize, clusterName, vpcSubnetIds]) => `
                 AWSTemplateFormatVersion: '2010-09-09'
                 Resources:
@@ -471,4 +473,11 @@ ${customUserData}
 
         this.registerOutputs({ kubeconfig: this.kubeconfig });
     }
+}
+
+async function computeWorkerSubnets(parent: pulumi.Resource, subnetIds: string[]): Promise<string[]> {
+    const subnets = await Promise.all(subnetIds.map(id => aws.ec2.getSubnet({id}, { parent: parent })));
+    const publicSubnets = subnets.filter(s => s.mapPublicIpOnLaunch);
+    const privateSubnets = subnets.filter(s => !s.mapPublicIpOnLaunch);
+    return (privateSubnets.length === 0 ? publicSubnets : privateSubnets).map(s => s.id);
 }


### PR DESCRIPTION
If both public and private subnets are attached to an EKS cluster, the
API server will only be exposed to the private subnets. Any workers
attached to the public subnets will be unable to contact the API server
and will fail to register as nodes. These changes filter public subnets
from the set of subnets passed to the worker nodes iff the EKS cluster
is also attached to private subnets.

Fixes #18.