### PR TITLE
support creating multiple nodegroups

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -633,6 +633,11 @@ ${customUserData}
         if (args.maxSize === undefined) {
             args.maxSize = 2;
         }
+
+        let minInstancesInService = 1;
+        if (args.spotPrice) {
+            minInstancesInService = 0;
+        }
         const cfnTemplateBody = pulumi.all([
             nodeLaunchConfiguration.id,
             args.desiredCapacity,
@@ -660,7 +665,7 @@ ${customUserData}
                     PropagateAtLaunch: 'true'
                 UpdatePolicy:
                   AutoScalingRollingUpdate:
-                    MinInstancesInService: '1'
+                    MinInstancesInService: '${minInstancesInService}'
                     MaxBatchSize: '1'
             `);
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -30,12 +30,23 @@ import transform from "./transform";
  * ClusterOptions describes the configuration options accepted by an EKSCluster component.
  */
 export interface NodeGroupOptions {
-    keyName?: pulumi.Input<string>;
-
+   /**
+     * The AMI to use for the cluster's nodes. Defaults to AWS's official eks-node AMI.
+     */
     workerAmiArgs?: aws.GetAmiArgs;
 
+    /**
+     * The subnets to attach to the node group. If the list of subnets includes
+     * both public and private subnets, the Kubernetes API server and the worker
+     * nodes will only be attached to the private subnets. See
+     * https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html for
+     * more details.
+     */
     subnetIds?: pulumi.Input<pulumi.Input<string>[]>;
 
+    /**
+     * Bidding price for spot instance. If set, only spot instances will be added as workder node
+     */
     spotPrice?: pulumi.Input<string>;
 
     /**
@@ -49,6 +60,11 @@ export interface NodeGroupOptions {
      * If not provided, no SSH access is enabled on VMs.
      */
     nodePublicKey?: pulumi.Input<string>;
+
+    /**
+     * Name of the key pair to use for SSH access to workder nodes.
+     */
+    keyName?: pulumi.Input<string>;
 
     /**
      * The size in GiB of a cluster node's root volume. Defaults to 20.

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -30,7 +30,10 @@ import transform from "./transform";
  * ClusterOptions describes the configuration options accepted by an EKSCluster component.
  */
 export interface NodeGroupOptions {
+    keyName?: pulumi.Input<string>;
+
     workerAmiArgs?: aws.GetAmiArgs;
+
     subnetIds?: pulumi.Input<pulumi.Input<string>[]>;
 
     spotPrice?: pulumi.Input<string>;
@@ -593,7 +596,7 @@ ${customUserData}
         }, { parent: this });
 
         // If requested, add a new EC2 KeyPair for SSH access to the instances.
-        let keyName: pulumi.Output<string> | undefined;
+        let keyName = args.keyName;
         if (args.nodePublicKey) {
             const key = new aws.ec2.KeyPair(`${name}-keyPair`, {
                 publicKey: args.nodePublicKey,

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -14,6 +14,7 @@
         "@pulumi/aws": "dev",
         "@pulumi/kubernetes": "^v0.17.0",
         "@pulumi/pulumi": "dev",
+        "tmp": "0.0.33",
         "which": "^1.3.1"
     },
     "devDependencies": {

--- a/nodejs/eks/yarn.lock
+++ b/nodejs/eks/yarn.lock
@@ -954,7 +954,7 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tmp@^0.0.33:
+tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:


### PR DESCRIPTION
example usage:

```ts
const cluster = new eks.Cluster(clusterName, {
    vpcId: vpc.vpcId,
    subnetIds: vpc.subnetIds,
    skipDefaultNodeGroup: true,
});

cluster.createNodeGroup('cpuSpot', {
    subnetIds: vpc.subnetIds,,
    instanceType: "t2.medium",
    spotPrice: "4",
});

cluster.createNodeGroup('cpuOndemand', {
    subnetIds: vpc.subnetIds,,
    instanceType: "t2.medium",
});
```

First time working on pulumi module (and typescript), not sure whether this the right way to implement the feature. Open to any suggestions!

PS: this PR also contains a fix for spot instance support, happy to move those commits to a separate PR if you prefer that way.