### PR TITLE
Allow explicit node subnets

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -564,14 +564,30 @@ ${customUserData}
     }
 }
 
+// computeWorkerSubnets attempts to determine the subset of the given subnets to use for worker nodes.
+//
+// As per https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html, an EKS cluster that is attached to public
+// and private subnets will only expose its API service to workers on the private subnets. Any workers attached to the
+// public subnets will be unable to communicate with the API server.
+//
+// If all of the given subnet IDs are public, the list of subnet IDs is returned as-is. If any private subnet is given,
+// only the IDs of the private subnets are returned. A subnet is deemed private iff it has no route in its route table
+// that routes directly to an internet gateway. If any such route exists in a subnet's route table, it is treated as
+// public.
 async function computeWorkerSubnets(parent: pulumi.Resource, subnetIds: string[]): Promise<string[]> {
     const publicSubnets: string[] = [];
     const privateSubnets: string[] = [];
     for (const subnetId of subnetIds) {
+        // Fetch the route table for this subnet.
         const routeTable = await (async () => {
             try  {
+                // Attempt to get the explicit route table for this subnet. If there is no explicit rouute table for
+                // this subnet, this call will throw.
                 return await aws.ec2.getRouteTable({ subnetId: subnetId }, { parent: parent });
             } catch {
+                // If we reach this point, the subnet may not have an explicitly associated route table. In this case
+                // the subnet is associated with its VPC's main route table (see
+                // https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#RouteTables for details).
                 const subnet = await aws.ec2.getSubnet({ id: subnetId }, { parent: parent });
                 const mainRouteTableInfo = await aws.ec2.getRouteTables({
                     vpcId: subnet.vpcId,
@@ -583,6 +599,8 @@ async function computeWorkerSubnets(parent: pulumi.Resource, subnetIds: string[]
                 return await aws.ec2.getRouteTable({ routeTableId: mainRouteTableInfo.ids[0] }, { parent: parent });
             }
         })();
+
+        // Once we have the route table, check its list of routes for a route to an internet gateway.
         const hasInternetGatewayRoute = routeTable.routes.find(r => !!r.gatewayId) !== undefined;
         if (hasInternetGatewayRoute) {
             publicSubnets.push(subnetId);


### PR DESCRIPTION
And improve subnet filtering. Explicit subnets for worker nodes can be
specified if the automatic filtering does not work as expected.
The automatic filtering has been improved by using the presence of a
route to an internet gateway in a subnet's route table as the indicator
that the subnet is a public subnet.